### PR TITLE
Fixed 2 issues of type: PYTHON_F401 throughout 2 files in repo.

### DIFF
--- a/apis/googl.py
+++ b/apis/googl.py
@@ -1,6 +1,5 @@
 import os
 import json
-import urllib
 import logging
 
 from google.appengine.api import urlfetch

--- a/apis/telegram.py
+++ b/apis/telegram.py
@@ -1,6 +1,5 @@
 import os
 import json
-import urllib
 import logging
 
 from google.appengine.api import urlfetch


### PR DESCRIPTION
PYTHON_F401: 'Module imported but unused.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.        

It was fixed with <a href='https://github.com/myint/autoflake'>autoflake</a>.        

This fix is probably safe because the module was not called anywhere.  But if the removed module had global side-effects,        these will be missing and could cause issues.        